### PR TITLE
Allow passing CuPy arrays to Matrix replace_coefficients

### DIFF
--- a/pyamgx/Matrix.pyx
+++ b/pyamgx/Matrix.pyx
@@ -182,21 +182,13 @@ cdef class Matrix:
             Array of matrix data.
         """
         cdef int n, nnz
-        
-        if hasattr(data, "__array_interface__"):
-            desc = data.__array_interface__
-        elif hasattr(data, "__cuda_array_interface__"):
-            desc = data.__cuda_array_interface__
-        else:
-            raise TypeError("Must pass array-like for data")
-            
-        cdef uintptr_t ptr = desc["data"][0]
+        cdef uintptr_t data_ptr = ptr_from_array_interface(data, check_for_dtype="float64")
         
         size, (bx, by) = self.get_size()
         n = self.get_size()[0]
         nnz = self.get_nnz()
         check_error(AMGX_matrix_replace_coefficients(
-            self.mtx, n, nnz, <void *> ptr, NULL))
+            self.mtx, n, nnz, <void *> data_ptr, NULL))
 
         
     def destroy(self):

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -122,3 +122,12 @@ class TestMatrix:
         M.replace_coefficients(
             np.array([1., 0., 3.]))
         M.destroy()
+
+    def test_replace_coefficients_device(self):
+        import scipy.sparse
+        M = pyamgx.Matrix().create(self.rsrc)
+        M.upload_CSR(scipy.sparse.csr_matrix(
+            np.array([[0., 1.], [2., 3.]])))
+        M.replace_coefficients(
+            cp.array([1., 0., 3.]))
+        M.destroy()


### PR DESCRIPTION
I've implemented this feature and unit test for it in the same manner as for Matrix upload_CSR method.