### PR TITLE
Add shape parameter for `Matrix.upload`

### DIFF
--- a/pyamgx/Matrix.pyx
+++ b/pyamgx/Matrix.pyx
@@ -84,7 +84,6 @@ cdef class Matrix:
         else:
             nrows = shape[0]
             ncols = shape[1]
-        print(nrows, ncols)
         self.shape = nrows, ncols
 
         cdef uintptr_t row_ptrs_ptr = ptr_from_array_interface(

--- a/pyamgx/Matrix.pyx
+++ b/pyamgx/Matrix.pyx
@@ -23,6 +23,7 @@ cdef class Matrix:
 
     """
     cdef AMGX_matrix_handle mtx
+    cdef int shape[2]
 
     def create(self, Resources rsrc, mode='dDDI'):
         """
@@ -44,7 +45,7 @@ cdef class Matrix:
         check_error(AMGX_matrix_create(&self.mtx, rsrc.rsrc, asMode(mode)))
         return self
 
-    def upload(self, row_ptrs, col_indices, data, block_dims=[1, 1]):
+    def upload(self, row_ptrs, col_indices, data, block_dims=[1, 1], shape=None):
         """
         M.upload(row_ptrs, col_indices, data, block_dims=[1, 1])
 
@@ -71,12 +72,20 @@ cdef class Matrix:
         self : Matrix
         """
         cdef int block_dimx, block_dimy
+        cdef int nrows, ncols
 
         block_dimx = block_dims[0]
         block_dimy = block_dims[1]
 
         nnz = len(data)
-        nrows = len(row_ptrs) - 1
+        if shape is None:
+            nrows = len(row_ptrs) - 1
+            ncols = col_indices.max() + 1
+        else:
+            nrows = shape[0]
+            ncols = shape[1]
+        print(nrows, ncols)
+        self.shape = nrows, ncols
 
         cdef uintptr_t row_ptrs_ptr = ptr_from_array_interface(
             row_ptrs, "int32"
@@ -124,7 +133,7 @@ cdef class Matrix:
             data = data.__class__((1,), dtype=np.float64)
             data.fill(0)
 
-        self.upload(row_ptrs, col_indices, data)
+        self.upload(row_ptrs, col_indices, data, shape=[nrows, ncols])
         return self
 
     def get_size(self):

--- a/pyamgx/Solver.pyx
+++ b/pyamgx/Solver.pyx
@@ -74,6 +74,8 @@ cdef class Solver:
         b_size, _ = b.get_size()
         x_size, _ = x.get_size()
 
+        if self.A.shape[0] != self.A.shape[1]:
+            raise ValueError, "Matrix is not square: {} != {}".format(self.A.shape[0], self.A.shape[1])
         if A_size != b_size:
             raise ValueError, "Matrix - RHS dimension mismatch: {} != {}".format(
                 A_size, b_size)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -100,6 +100,16 @@ class TestMatrix:
             )
         ))
         M.destroy()
+    
+    def test_upload_CSR_zero_rows(self):
+        M = pyamgx.Matrix()
+        M.create(self.rsrc)
+        M.upload_CSR(cp.sparse.csr_matrix(
+            scipy.sparse.csr_matrix(
+                np.array([[1., 2., 0.], [3., 4., 0.], [0., 0., 0.]])
+            )
+        ))
+        M.destroy()
         
     def test_upload_CSR_singular(self):
         M = pyamgx.Matrix()

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -88,6 +88,33 @@ class TestSolver:
         M.destroy()
         x.destroy()
         b.destroy()
+        
+    def test_solve_matrix_rectangular(self):
+        M = pyamgx.Matrix().create(self.rsrc)
+        x = pyamgx.Vector().create(self.rsrc)
+        b = pyamgx.Vector().create(self.rsrc)
+        
+        ''' Matrix:
+            1, 2, 0
+            2, 1, 0
+        '''
+        M.upload(
+            np.array([0, 2, 4], dtype=np.int32), 
+            np.array([0, 1, 0, 1], dtype=np.int32), 
+            np.array([1., 2., 2., 1.], dtype=np.float64)
+        )
+        
+        x.upload(np.zeros(3, dtype=np.float64))
+        b.upload(np.array([1, 2], dtype=np.float64))
+        solver = pyamgx.Solver().create(self.rsrc, self.cfg)
+        solver.setup(M)
+        with pytest.raises(ValueError):
+            solver.solve(b, x)
+
+        solver.destroy()
+        M.destroy()
+        x.destroy()
+        b.destroy()
 
     def test_solve_no_setup(self):
         x = pyamgx.Vector().create(self.rsrc)


### PR DESCRIPTION
#23 
Now it works as described [here](https://github.com/shwina/pyamgx/issues/23#issuecomment-759777427).
I did not add a test for [my case](https://github.com/shwina/pyamgx/issues/23) with zero last row. Seems like this is really not an expected behavior, because default solver from empty config fails it. I have tested with matrix:
```
1, 2, 0
2, 1, 0
0, 0, 0
```
and RHS [2, 1, 0]. Still, some solvers can handle it, so it is useful for me.
Please study my code, I'm not a pro with cython so I could break something.