### PR TITLE
Added noexcept to c_print_callback in System.pyx to resolve compile-time error

### DIFF
--- a/pyamgx/System.pyx
+++ b/pyamgx/System.pyx
@@ -49,7 +49,7 @@ def reset_signal_handler():
 cdef void c_register_print_callback(AMGX_print_callback function):
     AMGX_register_print_callback(function)
 
-cdef void c_print_callback(char *msg, int length):
+cdef void c_print_callback(char *msg, int length) noexcept:
     global print_callback
     print_callback(msg.decode('utf-8'))
 


### PR DESCRIPTION
This modification prevents the following error on my machine:

```
$ pip install .
Processing /path/pyamgx
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [28 lines of output]
      /path/wenv/lib/python3.10/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /path/pyamgx/pyamgx/pyamgx.pyx
        tree = Parsing.p_module(s, pxd, full_module_name)
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          # as a user-provided context,
          # print_callback can be passed as that argument without
          # defining it globally.
          global print_callback
          print_callback = f
          c_register_print_callback(c_print_callback)
                                    ^
      ------------------------------------------------------------
      
      pyamgx/System.pyx:94:30: Cannot assign type 'void (char *, int) except *' to 'AMGX_print_callback' (alias of 'void (*)(const char *, int) noexcept'). Exception values are incompatible. Suggest adding 'noexcept' to the type of 'c_print_callback'.
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/path/pyamgx/setup.py", line 61, in <module>
          ext = cythonize([
        File "/path/wenv/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1154, in cythonize
          cythonize_one(*args)
        File "/path/wenv/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1321, in cythonize_one
          raise CompileError(None, pyx_file)
      Cython.Compiler.Errors.CompileError: pyamgx/pyamgx.pyx
      Compiling pyamgx/pyamgx.pyx because it changed.
      [1/1] Cythonizing pyamgx/pyamgx.pyx
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
